### PR TITLE
add function to allow setting aws.Config struct

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -66,9 +66,15 @@ func (s *Service) Backup(n string) *Service {
 
 // NewService creates new worker service
 func NewService(n string) (*Service, error) {
+	return NewServiceWithConfig(n, aws.Config{})
+}
+
+// NewServiceWithConfig creates a new worker service with the specified AWS config
+func NewServiceWithConfig(n string, config aws.Config) (*Service, error) {
 	// Setting up SQS connection
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
+		Config:            config,
 	}))
 	s := sqs.New(sess)
 


### PR DESCRIPTION
I'm looking to read from queues across multiple regions, this change allows connection to queues outside of initial connection region.